### PR TITLE
Switch to using `head` to avoid bogus p tags

### DIFF
--- a/Send to Instapaper.workflow/Contents/document.wflow
+++ b/Send to Instapaper.workflow/Contents/document.wflow
@@ -413,7 +413,7 @@
 				<key>ActionParameters</key>
 				<dict>
 					<key>COMMAND_STRING</key>
-					<string>tail -1</string>
+					<string>head -1</string>
 					<key>CheckedForUserDefaultShell</key>
 					<true/>
 					<key>inputMethod</key>


### PR DESCRIPTION
I keep getting issues where this attempts to submit a URL with a `</p>` tag to Instapaper.

I found that the output of the "find URLs" item, when pointed at a rich text-derived link like `<a href="http://foo"><p>http://foo</p></a>` often catches the paragraph tags.

Switching to the first URL returned (using `head`) fixes this issue, and will likely make this more reliable when URL-like things appear in link text.
